### PR TITLE
feat: sapmple liff provider :sparkles:

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,12 +7,15 @@
       "name": "server-main",
       "dependencies": {
         "@line/bot-sdk": "^7.5.2",
+        "@line/liff": "^2.22.3",
+        "@line/liff-mock": "^1.0.3",
         "@prisma/client": "^4.14.1",
         "@tailwindcss/forms": "^0.5.4",
         "aws-amplify": "^5.2.1",
         "aws-sdk": "^2.1359.0",
         "classnames": "^2.3.2",
         "dayjs": "^1.11.7",
+        "firebase": "^10.3.1",
         "lodash": "^4.17.21",
         "next": "^13.0.6",
         "next-connect": "^0.13.0",
@@ -21,6 +24,7 @@
         "react-hot-toast": "^2.4.0",
         "react-icons": "^4.9.0",
         "react-swipeable": "^7.0.0",
+        "recoil": "^0.7.7",
         "sharp": "^0.32.4",
         "swr": "^2.1.5",
         "uuid": "^9.0.0"
@@ -9659,6 +9663,808 @@
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
+    "node_modules/@firebase/analytics": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@firebase/analytics/-/analytics-0.10.0.tgz",
+      "integrity": "sha512-Locv8gAqx0e+GX/0SI3dzmBY5e9kjVDtD+3zCFLJ0tH2hJwuCAiL+5WkHuxKj92rqQj/rvkBUCfA1ewlX2hehg==",
+      "dependencies": {
+        "@firebase/component": "0.6.4",
+        "@firebase/installations": "0.6.4",
+        "@firebase/logger": "0.4.0",
+        "@firebase/util": "1.9.3",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/analytics-compat": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/@firebase/analytics-compat/-/analytics-compat-0.2.6.tgz",
+      "integrity": "sha512-4MqpVLFkGK7NJf/5wPEEP7ePBJatwYpyjgJ+wQHQGHfzaCDgntOnl9rL2vbVGGKCnRqWtZDIWhctB86UWXaX2Q==",
+      "dependencies": {
+        "@firebase/analytics": "0.10.0",
+        "@firebase/analytics-types": "0.8.0",
+        "@firebase/component": "0.6.4",
+        "@firebase/util": "1.9.3",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/analytics-types": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@firebase/analytics-types/-/analytics-types-0.8.0.tgz",
+      "integrity": "sha512-iRP+QKI2+oz3UAh4nPEq14CsEjrjD6a5+fuypjScisAh9kXKFvdJOZJDwk7kikLvWVLGEs9+kIUS4LPQV7VZVw=="
+    },
+    "node_modules/@firebase/app": {
+      "version": "0.9.18",
+      "resolved": "https://registry.npmjs.org/@firebase/app/-/app-0.9.18.tgz",
+      "integrity": "sha512-SIJi3B/LzNezaEgbFCFIem12+51khkA3iewYljPQPUArWGSAr1cO9NK8TvtJWax5GMKSmQbJPqgi6a+gxHrWGQ==",
+      "dependencies": {
+        "@firebase/component": "0.6.4",
+        "@firebase/logger": "0.4.0",
+        "@firebase/util": "1.9.3",
+        "idb": "7.1.1",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@firebase/app-check": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@firebase/app-check/-/app-check-0.8.0.tgz",
+      "integrity": "sha512-dRDnhkcaC2FspMiRK/Vbp+PfsOAEP6ZElGm9iGFJ9fDqHoPs0HOPn7dwpJ51lCFi1+2/7n5pRPGhqF/F03I97g==",
+      "dependencies": {
+        "@firebase/component": "0.6.4",
+        "@firebase/logger": "0.4.0",
+        "@firebase/util": "1.9.3",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/app-check-compat": {
+      "version": "0.3.7",
+      "resolved": "https://registry.npmjs.org/@firebase/app-check-compat/-/app-check-compat-0.3.7.tgz",
+      "integrity": "sha512-cW682AxsyP1G+Z0/P7pO/WT2CzYlNxoNe5QejVarW2o5ZxeWSSPAiVEwpEpQR/bUlUmdeWThYTMvBWaopdBsqw==",
+      "dependencies": {
+        "@firebase/app-check": "0.8.0",
+        "@firebase/app-check-types": "0.5.0",
+        "@firebase/component": "0.6.4",
+        "@firebase/logger": "0.4.0",
+        "@firebase/util": "1.9.3",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/app-check-interop-types": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@firebase/app-check-interop-types/-/app-check-interop-types-0.3.0.tgz",
+      "integrity": "sha512-xAxHPZPIgFXnI+vb4sbBjZcde7ZluzPPaSK7Lx3/nmuVk4TjZvnL8ONnkd4ERQKL8WePQySU+pRcWkh8rDf5Sg=="
+    },
+    "node_modules/@firebase/app-check-types": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@firebase/app-check-types/-/app-check-types-0.5.0.tgz",
+      "integrity": "sha512-uwSUj32Mlubybw7tedRzR24RP8M8JUVR3NPiMk3/Z4bCmgEKTlQBwMXrehDAZ2wF+TsBq0SN1c6ema71U/JPyQ=="
+    },
+    "node_modules/@firebase/app-compat": {
+      "version": "0.2.18",
+      "resolved": "https://registry.npmjs.org/@firebase/app-compat/-/app-compat-0.2.18.tgz",
+      "integrity": "sha512-zUbAAZHhwmMUyaNFiFr+1Z/sfcxSQBFrRhpjzzpQMTfiV2C/+P0mC3BQA0HsysdGSYOlwrCs5rEGOyarhRU9Kw==",
+      "dependencies": {
+        "@firebase/app": "0.9.18",
+        "@firebase/component": "0.6.4",
+        "@firebase/logger": "0.4.0",
+        "@firebase/util": "1.9.3",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@firebase/app-types": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@firebase/app-types/-/app-types-0.9.0.tgz",
+      "integrity": "sha512-AeweANOIo0Mb8GiYm3xhTEBVCmPwTYAu9Hcd2qSkLuga/6+j9b1Jskl5bpiSQWy9eJ/j5pavxj6eYogmnuzm+Q=="
+    },
+    "node_modules/@firebase/app/node_modules/idb": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/idb/-/idb-7.1.1.tgz",
+      "integrity": "sha512-gchesWBzyvGHRO9W8tzUWFDycow5gwjvFKfyV9FF32Y7F50yZMp7mP+T2mJIWFx49zicqyC4uefHM17o6xKIVQ=="
+    },
+    "node_modules/@firebase/auth": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@firebase/auth/-/auth-1.3.0.tgz",
+      "integrity": "sha512-vjK4CHbY9aWdiVOrKi6mpa8z6uxeaf7LB/MZTHuZOiGHMcUoTGB6TeMbRShyqk1uaMrxhhZ5Ar/dR0965E1qyA==",
+      "dependencies": {
+        "@firebase/component": "0.6.4",
+        "@firebase/logger": "0.4.0",
+        "@firebase/util": "1.9.3",
+        "node-fetch": "2.6.7",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x",
+        "@react-native-async-storage/async-storage": "^1.18.1"
+      },
+      "peerDependenciesMeta": {
+        "@react-native-async-storage/async-storage": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@firebase/auth-compat": {
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/@firebase/auth-compat/-/auth-compat-0.4.6.tgz",
+      "integrity": "sha512-pKp1d4fSf+yoy1EBjTx9ISxlunqhW0vTICk0ByZ3e+Lp6ZIXThfUy4F1hAJlEafD/arM0oepRiAh7LXS1xn/BA==",
+      "dependencies": {
+        "@firebase/auth": "1.3.0",
+        "@firebase/auth-types": "0.12.0",
+        "@firebase/component": "0.6.4",
+        "@firebase/util": "1.9.3",
+        "node-fetch": "2.6.7",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/auth-compat/node_modules/node-fetch": {
+      "version": "2.6.7",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@firebase/auth-compat/node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+    },
+    "node_modules/@firebase/auth-compat/node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+    },
+    "node_modules/@firebase/auth-compat/node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
+    "node_modules/@firebase/auth-interop-types": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@firebase/auth-interop-types/-/auth-interop-types-0.2.1.tgz",
+      "integrity": "sha512-VOaGzKp65MY6P5FI84TfYKBXEPi6LmOCSMMzys6o2BN2LOsqy7pCuZCup7NYnfbk5OkkQKzvIfHOzTm0UDpkyg=="
+    },
+    "node_modules/@firebase/auth-types": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@firebase/auth-types/-/auth-types-0.12.0.tgz",
+      "integrity": "sha512-pPwaZt+SPOshK8xNoiQlK5XIrS97kFYc3Rc7xmy373QsOJ9MmqXxLaYssP5Kcds4wd2qK//amx/c+A8O2fVeZA==",
+      "peerDependencies": {
+        "@firebase/app-types": "0.x",
+        "@firebase/util": "1.x"
+      }
+    },
+    "node_modules/@firebase/auth/node_modules/node-fetch": {
+      "version": "2.6.7",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@firebase/auth/node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+    },
+    "node_modules/@firebase/auth/node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+    },
+    "node_modules/@firebase/auth/node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
+    "node_modules/@firebase/component": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.6.4.tgz",
+      "integrity": "sha512-rLMyrXuO9jcAUCaQXCMjCMUsWrba5fzHlNK24xz5j2W6A/SRmK8mZJ/hn7V0fViLbxC0lPMtrK1eYzk6Fg03jA==",
+      "dependencies": {
+        "@firebase/util": "1.9.3",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@firebase/database": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@firebase/database/-/database-1.0.1.tgz",
+      "integrity": "sha512-VAhF7gYwunW4Lw/+RQZvW8dlsf2r0YYqV9W0Gi2Mz8+0TGg1mBJWoUtsHfOr8kPJXhcLsC4eP/z3x6L/Fvjk/A==",
+      "dependencies": {
+        "@firebase/auth-interop-types": "0.2.1",
+        "@firebase/component": "0.6.4",
+        "@firebase/logger": "0.4.0",
+        "@firebase/util": "1.9.3",
+        "faye-websocket": "0.11.4",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@firebase/database-compat": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@firebase/database-compat/-/database-compat-1.0.1.tgz",
+      "integrity": "sha512-ky82yLIboLxtAIWyW/52a6HLMVTzD2kpZlEilVDok73pNPLjkJYowj8iaIWK5nTy7+6Gxt7d00zfjL6zckGdXQ==",
+      "dependencies": {
+        "@firebase/component": "0.6.4",
+        "@firebase/database": "1.0.1",
+        "@firebase/database-types": "1.0.0",
+        "@firebase/logger": "0.4.0",
+        "@firebase/util": "1.9.3",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@firebase/database-types": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@firebase/database-types/-/database-types-1.0.0.tgz",
+      "integrity": "sha512-SjnXStoE0Q56HcFgNQ+9SsmJc0c8TqGARdI/T44KXy+Ets3r6x/ivhQozT66bMnCEjJRywYoxNurRTMlZF8VNg==",
+      "dependencies": {
+        "@firebase/app-types": "0.9.0",
+        "@firebase/util": "1.9.3"
+      }
+    },
+    "node_modules/@firebase/firestore": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/@firebase/firestore/-/firestore-4.1.3.tgz",
+      "integrity": "sha512-3kw/oZrLAIHuSDTAlKguZ1e0hAgWgiBl4QQm2mIPBvBAs++iEkuv9DH2tr6rbYpT6dWtdn6jj0RN0XeqOouJRg==",
+      "dependencies": {
+        "@firebase/component": "0.6.4",
+        "@firebase/logger": "0.4.0",
+        "@firebase/util": "1.9.3",
+        "@firebase/webchannel-wrapper": "0.10.2",
+        "@grpc/grpc-js": "~1.8.17",
+        "@grpc/proto-loader": "^0.7.8",
+        "node-fetch": "2.6.7",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=10.10.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/firestore-compat": {
+      "version": "0.3.17",
+      "resolved": "https://registry.npmjs.org/@firebase/firestore-compat/-/firestore-compat-0.3.17.tgz",
+      "integrity": "sha512-Qh3tbE4vkn9XvyWnRaJM/v4vhCZ+btk2RZcq037o6oECHohaCFortevd/SKA4vA5yOx0/DwARIEv6XwgHkVucg==",
+      "dependencies": {
+        "@firebase/component": "0.6.4",
+        "@firebase/firestore": "4.1.3",
+        "@firebase/firestore-types": "3.0.0",
+        "@firebase/util": "1.9.3",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/firestore-types": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@firebase/firestore-types/-/firestore-types-3.0.0.tgz",
+      "integrity": "sha512-Meg4cIezHo9zLamw0ymFYBD4SMjLb+ZXIbuN7T7ddXN6MGoICmOTq3/ltdCGoDCS2u+H1XJs2u/cYp75jsX9Qw==",
+      "peerDependencies": {
+        "@firebase/app-types": "0.x",
+        "@firebase/util": "1.x"
+      }
+    },
+    "node_modules/@firebase/firestore/node_modules/node-fetch": {
+      "version": "2.6.7",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@firebase/firestore/node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+    },
+    "node_modules/@firebase/firestore/node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+    },
+    "node_modules/@firebase/firestore/node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
+    "node_modules/@firebase/functions": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@firebase/functions/-/functions-0.10.0.tgz",
+      "integrity": "sha512-2U+fMNxTYhtwSpkkR6WbBcuNMOVaI7MaH3cZ6UAeNfj7AgEwHwMIFLPpC13YNZhno219F0lfxzTAA0N62ndWzA==",
+      "dependencies": {
+        "@firebase/app-check-interop-types": "0.3.0",
+        "@firebase/auth-interop-types": "0.2.1",
+        "@firebase/component": "0.6.4",
+        "@firebase/messaging-interop-types": "0.2.0",
+        "@firebase/util": "1.9.3",
+        "node-fetch": "2.6.7",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/functions-compat": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/@firebase/functions-compat/-/functions-compat-0.3.5.tgz",
+      "integrity": "sha512-uD4jwgwVqdWf6uc3NRKF8cSZ0JwGqSlyhPgackyUPe+GAtnERpS4+Vr66g0b3Gge0ezG4iyHo/EXW/Hjx7QhHw==",
+      "dependencies": {
+        "@firebase/component": "0.6.4",
+        "@firebase/functions": "0.10.0",
+        "@firebase/functions-types": "0.6.0",
+        "@firebase/util": "1.9.3",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/functions-types": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@firebase/functions-types/-/functions-types-0.6.0.tgz",
+      "integrity": "sha512-hfEw5VJtgWXIRf92ImLkgENqpL6IWpYaXVYiRkFY1jJ9+6tIhWM7IzzwbevwIIud/jaxKVdRzD7QBWfPmkwCYw=="
+    },
+    "node_modules/@firebase/functions/node_modules/node-fetch": {
+      "version": "2.6.7",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@firebase/functions/node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+    },
+    "node_modules/@firebase/functions/node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+    },
+    "node_modules/@firebase/functions/node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
+    "node_modules/@firebase/installations": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/@firebase/installations/-/installations-0.6.4.tgz",
+      "integrity": "sha512-u5y88rtsp7NYkCHC3ElbFBrPtieUybZluXyzl7+4BsIz4sqb4vSAuwHEUgCgCeaQhvsnxDEU6icly8U9zsJigA==",
+      "dependencies": {
+        "@firebase/component": "0.6.4",
+        "@firebase/util": "1.9.3",
+        "idb": "7.0.1",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/installations-compat": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@firebase/installations-compat/-/installations-compat-0.2.4.tgz",
+      "integrity": "sha512-LI9dYjp0aT9Njkn9U4JRrDqQ6KXeAmFbRC0E7jI7+hxl5YmRWysq5qgQl22hcWpTk+cm3es66d/apoDU/A9n6Q==",
+      "dependencies": {
+        "@firebase/component": "0.6.4",
+        "@firebase/installations": "0.6.4",
+        "@firebase/installations-types": "0.5.0",
+        "@firebase/util": "1.9.3",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/installations-types": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@firebase/installations-types/-/installations-types-0.5.0.tgz",
+      "integrity": "sha512-9DP+RGfzoI2jH7gY4SlzqvZ+hr7gYzPODrbzVD82Y12kScZ6ZpRg/i3j6rleto8vTFC8n6Len4560FnV1w2IRg==",
+      "peerDependencies": {
+        "@firebase/app-types": "0.x"
+      }
+    },
+    "node_modules/@firebase/installations/node_modules/idb": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/idb/-/idb-7.0.1.tgz",
+      "integrity": "sha512-UUxlE7vGWK5RfB/fDwEGgRf84DY/ieqNha6msMV99UsEMQhJ1RwbCd8AYBj3QMgnE3VZnfQvm4oKVCJTYlqIgg=="
+    },
+    "node_modules/@firebase/logger": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@firebase/logger/-/logger-0.4.0.tgz",
+      "integrity": "sha512-eRKSeykumZ5+cJPdxxJRgAC3G5NknY2GwEbKfymdnXtnT0Ucm4pspfR6GT4MUQEDuJwRVbVcSx85kgJulMoFFA==",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@firebase/messaging": {
+      "version": "0.12.4",
+      "resolved": "https://registry.npmjs.org/@firebase/messaging/-/messaging-0.12.4.tgz",
+      "integrity": "sha512-6JLZct6zUaex4g7HI3QbzeUrg9xcnmDAPTWpkoMpd/GoSVWH98zDoWXMGrcvHeCAIsLpFMe4MPoZkJbrPhaASw==",
+      "dependencies": {
+        "@firebase/component": "0.6.4",
+        "@firebase/installations": "0.6.4",
+        "@firebase/messaging-interop-types": "0.2.0",
+        "@firebase/util": "1.9.3",
+        "idb": "7.0.1",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/messaging-compat": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@firebase/messaging-compat/-/messaging-compat-0.2.4.tgz",
+      "integrity": "sha512-lyFjeUhIsPRYDPNIkYX1LcZMpoVbBWXX4rPl7c/rqc7G+EUea7IEtSt4MxTvh6fDfPuzLn7+FZADfscC+tNMfg==",
+      "dependencies": {
+        "@firebase/component": "0.6.4",
+        "@firebase/messaging": "0.12.4",
+        "@firebase/util": "1.9.3",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/messaging-interop-types": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@firebase/messaging-interop-types/-/messaging-interop-types-0.2.0.tgz",
+      "integrity": "sha512-ujA8dcRuVeBixGR9CtegfpU4YmZf3Lt7QYkcj693FFannwNuZgfAYaTmbJ40dtjB81SAu6tbFPL9YLNT15KmOQ=="
+    },
+    "node_modules/@firebase/messaging/node_modules/idb": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/idb/-/idb-7.0.1.tgz",
+      "integrity": "sha512-UUxlE7vGWK5RfB/fDwEGgRf84DY/ieqNha6msMV99UsEMQhJ1RwbCd8AYBj3QMgnE3VZnfQvm4oKVCJTYlqIgg=="
+    },
+    "node_modules/@firebase/performance": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/@firebase/performance/-/performance-0.6.4.tgz",
+      "integrity": "sha512-HfTn/bd8mfy/61vEqaBelNiNnvAbUtME2S25A67Nb34zVuCSCRIX4SseXY6zBnOFj3oLisaEqhVcJmVPAej67g==",
+      "dependencies": {
+        "@firebase/component": "0.6.4",
+        "@firebase/installations": "0.6.4",
+        "@firebase/logger": "0.4.0",
+        "@firebase/util": "1.9.3",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/performance-compat": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@firebase/performance-compat/-/performance-compat-0.2.4.tgz",
+      "integrity": "sha512-nnHUb8uP9G8islzcld/k6Bg5RhX62VpbAb/Anj7IXs/hp32Eb2LqFPZK4sy3pKkBUO5wcrlRWQa6wKOxqlUqsg==",
+      "dependencies": {
+        "@firebase/component": "0.6.4",
+        "@firebase/logger": "0.4.0",
+        "@firebase/performance": "0.6.4",
+        "@firebase/performance-types": "0.2.0",
+        "@firebase/util": "1.9.3",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/performance-types": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@firebase/performance-types/-/performance-types-0.2.0.tgz",
+      "integrity": "sha512-kYrbr8e/CYr1KLrLYZZt2noNnf+pRwDq2KK9Au9jHrBMnb0/C9X9yWSXmZkFt4UIdsQknBq8uBB7fsybZdOBTA=="
+    },
+    "node_modules/@firebase/remote-config": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/@firebase/remote-config/-/remote-config-0.4.4.tgz",
+      "integrity": "sha512-x1ioTHGX8ZwDSTOVp8PBLv2/wfwKzb4pxi0gFezS5GCJwbLlloUH4YYZHHS83IPxnua8b6l0IXUaWd0RgbWwzQ==",
+      "dependencies": {
+        "@firebase/component": "0.6.4",
+        "@firebase/installations": "0.6.4",
+        "@firebase/logger": "0.4.0",
+        "@firebase/util": "1.9.3",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/remote-config-compat": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@firebase/remote-config-compat/-/remote-config-compat-0.2.4.tgz",
+      "integrity": "sha512-FKiki53jZirrDFkBHglB3C07j5wBpitAaj8kLME6g8Mx+aq7u9P7qfmuSRytiOItADhWUj7O1JIv7n9q87SuwA==",
+      "dependencies": {
+        "@firebase/component": "0.6.4",
+        "@firebase/logger": "0.4.0",
+        "@firebase/remote-config": "0.4.4",
+        "@firebase/remote-config-types": "0.3.0",
+        "@firebase/util": "1.9.3",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/remote-config-types": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@firebase/remote-config-types/-/remote-config-types-0.3.0.tgz",
+      "integrity": "sha512-RtEH4vdcbXZuZWRZbIRmQVBNsE7VDQpet2qFvq6vwKLBIQRQR5Kh58M4ok3A3US8Sr3rubYnaGqZSurCwI8uMA=="
+    },
+    "node_modules/@firebase/storage": {
+      "version": "0.11.2",
+      "resolved": "https://registry.npmjs.org/@firebase/storage/-/storage-0.11.2.tgz",
+      "integrity": "sha512-CtvoFaBI4hGXlXbaCHf8humajkbXhs39Nbh6MbNxtwJiCqxPy9iH3D3CCfXAvP0QvAAwmJUTK3+z9a++Kc4nkA==",
+      "dependencies": {
+        "@firebase/component": "0.6.4",
+        "@firebase/util": "1.9.3",
+        "node-fetch": "2.6.7",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/storage-compat": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@firebase/storage-compat/-/storage-compat-0.3.2.tgz",
+      "integrity": "sha512-wvsXlLa9DVOMQJckbDNhXKKxRNNewyUhhbXev3t8kSgoCotd1v3MmqhKKz93ePhDnhHnDs7bYHy+Qa8dRY6BXw==",
+      "dependencies": {
+        "@firebase/component": "0.6.4",
+        "@firebase/storage": "0.11.2",
+        "@firebase/storage-types": "0.8.0",
+        "@firebase/util": "1.9.3",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/storage-types": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@firebase/storage-types/-/storage-types-0.8.0.tgz",
+      "integrity": "sha512-isRHcGrTs9kITJC0AVehHfpraWFui39MPaU7Eo8QfWlqW7YPymBmRgjDrlOgFdURh6Cdeg07zmkLP5tzTKRSpg==",
+      "peerDependencies": {
+        "@firebase/app-types": "0.x",
+        "@firebase/util": "1.x"
+      }
+    },
+    "node_modules/@firebase/storage/node_modules/node-fetch": {
+      "version": "2.6.7",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@firebase/storage/node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+    },
+    "node_modules/@firebase/storage/node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+    },
+    "node_modules/@firebase/storage/node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
+    "node_modules/@firebase/util": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/@firebase/util/-/util-1.9.3.tgz",
+      "integrity": "sha512-DY02CRhOZwpzO36fHpuVysz6JZrscPiBXD0fXp6qSrL9oNOx5KWICKdR95C0lSITzxp0TZosVyHqzatE8JbcjA==",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@firebase/webchannel-wrapper": {
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@firebase/webchannel-wrapper/-/webchannel-wrapper-0.10.2.tgz",
+      "integrity": "sha512-xDxhD9++451HuCv3xKBEdSYaArX9NcokODXZYH/MxGw1XFFOz7OKkTRItZ5wf6npBN/inwp8dUZCP7SpAg46yQ=="
+    },
+    "node_modules/@grpc/grpc-js": {
+      "version": "1.8.21",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.8.21.tgz",
+      "integrity": "sha512-KeyQeZpxeEBSqFVTi3q2K7PiPXmgBfECc4updA1ejCLjYmoAlvvM3ZMp5ztTDUCUQmoY3CpDxvchjO1+rFkoHg==",
+      "dependencies": {
+        "@grpc/proto-loader": "^0.7.0",
+        "@types/node": ">=12.12.47"
+      },
+      "engines": {
+        "node": "^8.13.0 || >=10.10.0"
+      }
+    },
+    "node_modules/@grpc/proto-loader": {
+      "version": "0.7.9",
+      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.7.9.tgz",
+      "integrity": "sha512-YJsOehVXzgurc+lLAxYnlSMc1p/Gu6VAvnfx0ATi2nzvr0YZcjhmZDeY8SeAKv1M7zE3aEJH0Xo9mK1iZ8GYoQ==",
+      "dependencies": {
+        "lodash.camelcase": "^4.3.0",
+        "long": "^5.0.0",
+        "protobufjs": "^7.2.4",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "proto-loader-gen-types": "build/bin/proto-loader-gen-types.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@grpc/proto-loader/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@grpc/proto-loader/node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@grpc/proto-loader/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/@grpc/proto-loader/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+    },
+    "node_modules/@grpc/proto-loader/node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/@grpc/proto-loader/node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@grpc/proto-loader/node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/@hapi/hoek": {
       "version": "9.3.0",
       "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.3.0.tgz",
@@ -10651,6 +11457,635 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@liff/add-to-home-screen": {
+      "version": "2.22.3",
+      "resolved": "https://registry.npmjs.org/@liff/add-to-home-screen/-/add-to-home-screen-2.22.3.tgz",
+      "integrity": "sha512-JsR/O6iXVs+XajQ02Ut6nKFIr0sirLx8QZ+7Atqro7ujhCG87JbTScvRXwk6SWLL/F0SJiKqzI1K1if59L8dBg==",
+      "dependencies": {
+        "@liff/consts": "2.22.3",
+        "@liff/open-window": "2.22.3",
+        "@liff/types": "2.22.3",
+        "@liff/util": "2.22.3"
+      },
+      "peerDependencies": {
+        "tslib": "^2.3.0"
+      }
+    },
+    "node_modules/@liff/analytics": {
+      "version": "2.22.3",
+      "resolved": "https://registry.npmjs.org/@liff/analytics/-/analytics-2.22.3.tgz",
+      "integrity": "sha512-0mqdut+1oSn36umyNk75pGy9pM3D5JO3z7SWfbnWmcgZ9AU7mfiQ2uiAIVXeE8TInV7NzkT6PvzQjRss6rteDg==",
+      "dependencies": {
+        "@liff/consts": "2.22.3",
+        "@liff/core": "2.22.3",
+        "@liff/get-profile": "2.22.3",
+        "@liff/get-version": "2.22.3",
+        "@liff/is-logged-in": "2.22.3",
+        "@liff/logger": "2.22.3",
+        "@liff/store": "2.22.3",
+        "@liff/types": "2.22.3",
+        "@liff/use": "2.22.3",
+        "@liff/util": "2.22.3"
+      },
+      "peerDependencies": {
+        "tslib": "^2.3.0"
+      }
+    },
+    "node_modules/@liff/check-availability": {
+      "version": "2.22.3",
+      "resolved": "https://registry.npmjs.org/@liff/check-availability/-/check-availability-2.22.3.tgz",
+      "integrity": "sha512-TOw7r3m5xoPGWvr9SArBBNFRKfvmk1I60jRoEFFl73mQpIfYo1PTSTv/zk+2gczUf0k6OZ9L/p9C9JygJbBbBA==",
+      "dependencies": {
+        "@liff/get-version": "2.22.3",
+        "@liff/is-api-available": "2.22.3",
+        "@liff/types": "2.22.3",
+        "@liff/util": "2.22.3"
+      },
+      "peerDependencies": {
+        "tslib": "^2.3.0"
+      }
+    },
+    "node_modules/@liff/close-window": {
+      "version": "2.22.3",
+      "resolved": "https://registry.npmjs.org/@liff/close-window/-/close-window-2.22.3.tgz",
+      "integrity": "sha512-jldtGdBjOlCKVVjFIMPrfIBt2bFAVYFId1Bf0Cqgfb+Y1ZdFpUow2fZIZulbmKBIafebtf7oEU8LalpaSNKm1Q==",
+      "dependencies": {
+        "@liff/get-line-version": "2.22.3",
+        "@liff/get-os": "2.22.3",
+        "@liff/native-bridge": "2.22.3",
+        "@liff/types": "2.22.3",
+        "@liff/use": "2.22.3",
+        "@liff/util": "2.22.3"
+      },
+      "peerDependencies": {
+        "tslib": "^2.3.0"
+      }
+    },
+    "node_modules/@liff/consts": {
+      "version": "2.22.3",
+      "resolved": "https://registry.npmjs.org/@liff/consts/-/consts-2.22.3.tgz",
+      "integrity": "sha512-e7L6S+uCaJkLwNcxOvV/5N2VgIaztNeADXFr2ABtv/1bJGxSWOIoV0yQ4fK3vBgfE6gDLAEPOahFaTvD8t7Xcg==",
+      "peerDependencies": {
+        "tslib": "^2.3.0"
+      }
+    },
+    "node_modules/@liff/core": {
+      "version": "2.22.3",
+      "resolved": "https://registry.npmjs.org/@liff/core/-/core-2.22.3.tgz",
+      "integrity": "sha512-tP05ycQKKI/CtCrTNiNJwmnu7VntLT9EPdXKf/tiuUsnuLjHqItNBrzD5hkCMGojIIfCupcRlz6oaTF21kM9qQ==",
+      "dependencies": {
+        "@liff/get-version": "2.22.3",
+        "@liff/init": "2.22.3",
+        "@liff/native-bridge": "2.22.3",
+        "@liff/ready": "2.22.3",
+        "@liff/store": "2.22.3",
+        "@liff/use": "2.22.3"
+      },
+      "peerDependencies": {
+        "tslib": "^2.3.0"
+      }
+    },
+    "node_modules/@liff/extensions": {
+      "version": "2.22.3",
+      "resolved": "https://registry.npmjs.org/@liff/extensions/-/extensions-2.22.3.tgz",
+      "integrity": "sha512-x4xOFcEBbG/hhEqsK00G+ts8j1LvaoQaUfHAAT9GlPtJimeQJxL4DAf+jS/tVGKxCXVVVvNZ3HFxusr5gdBdmA==",
+      "dependencies": {
+        "@liff/add-to-home-screen": "2.22.3",
+        "@liff/check-availability": "2.22.3",
+        "@liff/consts": "2.22.3",
+        "@liff/get-advertising-id": "2.22.3",
+        "@liff/get-line-version": "2.22.3",
+        "@liff/get-os": "2.22.3",
+        "@liff/logger": "2.22.3",
+        "@liff/scan-code": "2.22.3",
+        "@liff/store": "2.22.3",
+        "@liff/types": "2.22.3",
+        "@liff/util": "2.22.3"
+      }
+    },
+    "node_modules/@liff/get-advertising-id": {
+      "version": "2.22.3",
+      "resolved": "https://registry.npmjs.org/@liff/get-advertising-id/-/get-advertising-id-2.22.3.tgz",
+      "integrity": "sha512-w1gXVxF+MMscr1I7/BuuizdsKlo1tf6MxO0t2cHNQ6/vJqbH1lo6ZancrH5Pp9lNhRfC7tvzzgbuG3cQtH5Gqw==",
+      "dependencies": {
+        "@liff/types": "2.22.3"
+      },
+      "peerDependencies": {
+        "tslib": "^2.3.0"
+      }
+    },
+    "node_modules/@liff/get-friendship": {
+      "version": "2.22.3",
+      "resolved": "https://registry.npmjs.org/@liff/get-friendship/-/get-friendship-2.22.3.tgz",
+      "integrity": "sha512-KuQRePDNhLMa3tWYpi7wuNHWpk164tuO2KpHegffOMG+DsMZBo6+8ivuL/S6FClYSp+rz9tL9GJNei/5rTfrjA==",
+      "dependencies": {
+        "@liff/permission": "2.22.3",
+        "@liff/server-api": "2.22.3",
+        "@liff/use": "2.22.3"
+      },
+      "peerDependencies": {
+        "tslib": "^2.3.0"
+      }
+    },
+    "node_modules/@liff/get-language": {
+      "version": "2.22.3",
+      "resolved": "https://registry.npmjs.org/@liff/get-language/-/get-language-2.22.3.tgz",
+      "integrity": "sha512-5wX0EY1u3W4wjfiGEgi6KWGdUsNWB5BRF6Q1AmqTyEgNBg0f2Ve+K11/SxSURe16x1/1h8bHF4gwXyjXKn9VWw==",
+      "dependencies": {
+        "@liff/use": "2.22.3"
+      },
+      "peerDependencies": {
+        "tslib": "^2.3.0"
+      }
+    },
+    "node_modules/@liff/get-line-version": {
+      "version": "2.22.3",
+      "resolved": "https://registry.npmjs.org/@liff/get-line-version/-/get-line-version-2.22.3.tgz",
+      "integrity": "sha512-qd7i86O1MPO/CHf5Upt+dTs67jYgr6U8BM7zSiu/Q2fYeDHKgDW3P84V/yYJ+sPEoTadLYSgMn8cISvrI8iuLw==",
+      "dependencies": {
+        "@liff/use": "2.22.3"
+      },
+      "peerDependencies": {
+        "tslib": "^2.3.0"
+      }
+    },
+    "node_modules/@liff/get-os": {
+      "version": "2.22.3",
+      "resolved": "https://registry.npmjs.org/@liff/get-os/-/get-os-2.22.3.tgz",
+      "integrity": "sha512-70e/KJSdWAf0wQWi7790uhZrBlfBS59uaZ3tfJXHVXt+DjPrpKwnKiqjytdR6WgIZzSHuL2gI3lYJy6E7f+1wg==",
+      "dependencies": {
+        "@liff/use": "2.22.3"
+      },
+      "peerDependencies": {
+        "tslib": "^2.3.0"
+      }
+    },
+    "node_modules/@liff/get-profile": {
+      "version": "2.22.3",
+      "resolved": "https://registry.npmjs.org/@liff/get-profile/-/get-profile-2.22.3.tgz",
+      "integrity": "sha512-g7zPjKDTPxVc+Y3qabKcCzauHfTrVbgBKdMej0MO4eMXSOQ7+VRKhVwMkWaJ/scJGXikj9sV1LFbaONQqMVxeQ==",
+      "dependencies": {
+        "@liff/permission": "2.22.3",
+        "@liff/server-api": "2.22.3",
+        "@liff/use": "2.22.3"
+      },
+      "peerDependencies": {
+        "tslib": "^2.3.0"
+      }
+    },
+    "node_modules/@liff/get-version": {
+      "version": "2.22.3",
+      "resolved": "https://registry.npmjs.org/@liff/get-version/-/get-version-2.22.3.tgz",
+      "integrity": "sha512-FCTjPOzR18r1mKjsKr4gyvPHwZjt0m0Qvtw3qv7cXbnTc58ZoovE6CCSbdGnxLz1daf9Qtji4KCa1dJ2xIjr8Q==",
+      "dependencies": {
+        "@liff/use": "2.22.3"
+      },
+      "peerDependencies": {
+        "tslib": "^2.3.0"
+      }
+    },
+    "node_modules/@liff/hooks": {
+      "version": "2.22.3",
+      "resolved": "https://registry.npmjs.org/@liff/hooks/-/hooks-2.22.3.tgz",
+      "integrity": "sha512-hIEpOah32Mx/B9h2HKY+DVHwI+IAqwbDSsfIwJtAU6jvA6gdvEOkk5Rcmx1ehl06aWGt2O/uTk9D5haNwdHwXA==",
+      "peerDependencies": {
+        "tslib": "^2.3.0"
+      }
+    },
+    "node_modules/@liff/i18n": {
+      "version": "2.22.3",
+      "resolved": "https://registry.npmjs.org/@liff/i18n/-/i18n-2.22.3.tgz",
+      "integrity": "sha512-AGyb0G3W1LQ6hPJcay0iskk3hXUuQSTIf98+bRaDKs2YR4UwEr7ps1ul538Mr9vOuNQo6HlVmf5PPW9mC9WRiw==",
+      "dependencies": {
+        "@liff/consts": "2.22.3",
+        "@liff/server-api": "2.22.3",
+        "@liff/use": "2.22.3",
+        "@liff/util": "2.22.3"
+      },
+      "peerDependencies": {
+        "tslib": "^2.3.0"
+      }
+    },
+    "node_modules/@liff/init": {
+      "version": "2.22.3",
+      "resolved": "https://registry.npmjs.org/@liff/init/-/init-2.22.3.tgz",
+      "integrity": "sha512-k0X50vrp+DBHgUHJjVE0uE7kGdzc+1iJ5xvMJxkeeN4MVURRaPpkDXrysi/uEKveHF41Z15f/KH28m/mdibCXg==",
+      "dependencies": {
+        "@liff/check-availability": "2.22.3",
+        "@liff/close-window": "2.22.3",
+        "@liff/consts": "2.22.3",
+        "@liff/extensions": "2.22.3",
+        "@liff/get-line-version": "2.22.3",
+        "@liff/get-os": "2.22.3",
+        "@liff/hooks": "2.22.3",
+        "@liff/i18n": "2.22.3",
+        "@liff/is-api-available": "2.22.3",
+        "@liff/is-in-client": "2.22.3",
+        "@liff/is-logged-in": "2.22.3",
+        "@liff/is-sub-window": "2.22.3",
+        "@liff/logger": "2.22.3",
+        "@liff/login": "2.22.3",
+        "@liff/logout": "2.22.3",
+        "@liff/message-bus": "2.22.3",
+        "@liff/native-bridge": "2.22.3",
+        "@liff/ready": "2.22.3",
+        "@liff/server-api": "2.22.3",
+        "@liff/store": "2.22.3",
+        "@liff/sub-window": "2.22.3",
+        "@liff/types": "2.22.3",
+        "@liff/use": "2.22.3",
+        "@liff/util": "2.22.3"
+      },
+      "peerDependencies": {
+        "tslib": "^2.3.0"
+      }
+    },
+    "node_modules/@liff/is-api-available": {
+      "version": "2.22.3",
+      "resolved": "https://registry.npmjs.org/@liff/is-api-available/-/is-api-available-2.22.3.tgz",
+      "integrity": "sha512-+BI2OVKDm41L4SKmfDNtP+4AuVwJ63mIF7Dw37IMHQy07QLyIpKLLI548FzwqaA+3dDOSpCZEv0ubAkOE+5l5Q==",
+      "dependencies": {
+        "@liff/consts": "2.22.3",
+        "@liff/get-line-version": "2.22.3",
+        "@liff/is-in-client": "2.22.3",
+        "@liff/is-logged-in": "2.22.3",
+        "@liff/is-sub-window": "2.22.3",
+        "@liff/store": "2.22.3",
+        "@liff/use": "2.22.3",
+        "@liff/util": "2.22.3"
+      },
+      "peerDependencies": {
+        "tslib": "^2.3.0"
+      }
+    },
+    "node_modules/@liff/is-in-client": {
+      "version": "2.22.3",
+      "resolved": "https://registry.npmjs.org/@liff/is-in-client/-/is-in-client-2.22.3.tgz",
+      "integrity": "sha512-DOO4RFz0x3vhL4ysa9kekYtSwaSQI4x1dB8dQ4vUYk62XGWfnl/kzoxwK98E+ecNvBPSbCgAKSfqkWZn8efEXw==",
+      "dependencies": {
+        "@liff/consts": "2.22.3",
+        "@liff/use": "2.22.3",
+        "@liff/util": "2.22.3"
+      },
+      "peerDependencies": {
+        "tslib": "^2.3.0"
+      }
+    },
+    "node_modules/@liff/is-logged-in": {
+      "version": "2.22.3",
+      "resolved": "https://registry.npmjs.org/@liff/is-logged-in/-/is-logged-in-2.22.3.tgz",
+      "integrity": "sha512-4AS3uMjBj9OtuCkpNOcl5MKBW4aCxi2eQPnb25mFc3WVwu+60lGdIqYOfL6w+lmu8XbDHMDuB+9uRKnBNjNslQ==",
+      "dependencies": {
+        "@liff/store": "2.22.3",
+        "@liff/use": "2.22.3"
+      },
+      "peerDependencies": {
+        "tslib": "^2.3.0"
+      }
+    },
+    "node_modules/@liff/is-sub-window": {
+      "version": "2.22.3",
+      "resolved": "https://registry.npmjs.org/@liff/is-sub-window/-/is-sub-window-2.22.3.tgz",
+      "integrity": "sha512-XqFvCRUSkw/dNkuX5b8BJwY2ZyAeQDKFh11WD1q7V3K3FC4VhhzC0dRourw49SEAqsiAj17bcNW85FtN0v4+3g==",
+      "dependencies": {
+        "@liff/consts": "2.22.3",
+        "@liff/is-in-client": "2.22.3",
+        "@liff/store": "2.22.3",
+        "@liff/use": "2.22.3",
+        "@liff/util": "2.22.3"
+      },
+      "peerDependencies": {
+        "tslib": "^2.3.0"
+      }
+    },
+    "node_modules/@liff/liff-types": {
+      "version": "2.22.3",
+      "resolved": "https://registry.npmjs.org/@liff/liff-types/-/liff-types-2.22.3.tgz",
+      "integrity": "sha512-KPgJIp9ND+ieRHf3I+CBFBjGYLCt3HbXenr5WqlUuPFRtHGX6mqt0Md/8ZwEcCIBB7/I2q0z6C6UlLIYsdu2NQ==",
+      "dependencies": {
+        "@liff/analytics": "2.22.3",
+        "@liff/close-window": "2.22.3",
+        "@liff/get-friendship": "2.22.3",
+        "@liff/get-language": "2.22.3",
+        "@liff/get-line-version": "2.22.3",
+        "@liff/get-os": "2.22.3",
+        "@liff/get-profile": "2.22.3",
+        "@liff/get-version": "2.22.3",
+        "@liff/i18n": "2.22.3",
+        "@liff/init": "2.22.3",
+        "@liff/is-api-available": "2.22.3",
+        "@liff/is-in-client": "2.22.3",
+        "@liff/is-logged-in": "2.22.3",
+        "@liff/is-sub-window": "2.22.3",
+        "@liff/login": "2.22.3",
+        "@liff/logout": "2.22.3",
+        "@liff/native-bridge": "2.22.3",
+        "@liff/open-window": "2.22.3",
+        "@liff/permanent-link": "2.22.3",
+        "@liff/permission": "2.22.3",
+        "@liff/ready": "2.22.3",
+        "@liff/scan-code-v2": "2.22.3",
+        "@liff/send-messages": "2.22.3",
+        "@liff/share-target-picker": "2.22.3",
+        "@liff/store": "2.22.3",
+        "@liff/sub-window": "2.22.3",
+        "@liff/use": "2.22.3"
+      },
+      "peerDependencies": {
+        "tslib": "^2.3.0"
+      }
+    },
+    "node_modules/@liff/logger": {
+      "version": "2.22.3",
+      "resolved": "https://registry.npmjs.org/@liff/logger/-/logger-2.22.3.tgz",
+      "integrity": "sha512-AwZfgI5Eg8zeFfiO8S4ly33puQYMiiUGWH2/bkUtFap5sPdrsut7FIbCNNDaGm9GpVPME7moeUlf6YrpIjieIQ==",
+      "peerDependencies": {
+        "tslib": "^2.3.0"
+      }
+    },
+    "node_modules/@liff/login": {
+      "version": "2.22.3",
+      "resolved": "https://registry.npmjs.org/@liff/login/-/login-2.22.3.tgz",
+      "integrity": "sha512-LD4W+qCsbehLPQyoMgznTeUMN2RVvW+Pv3NY2mIEJ3jlj9AwrUWhEb6+Y9bArQw6nl269RbS9Fg842H0iaQLPQ==",
+      "dependencies": {
+        "@liff/consts": "2.22.3",
+        "@liff/get-version": "2.22.3",
+        "@liff/hooks": "2.22.3",
+        "@liff/is-in-client": "2.22.3",
+        "@liff/is-sub-window": "2.22.3",
+        "@liff/logger": "2.22.3",
+        "@liff/server-api": "2.22.3",
+        "@liff/store": "2.22.3",
+        "@liff/sub-window": "2.22.3",
+        "@liff/use": "2.22.3",
+        "@liff/util": "2.22.3",
+        "tiny-sha256": "^1.0.2"
+      },
+      "peerDependencies": {
+        "tslib": "^2.3.0"
+      }
+    },
+    "node_modules/@liff/logout": {
+      "version": "2.22.3",
+      "resolved": "https://registry.npmjs.org/@liff/logout/-/logout-2.22.3.tgz",
+      "integrity": "sha512-aFar9jlOwg+jjmxNoIw5F62lLO9H1UwVCk/NYumi6kM5QuruuAHbwKTPmYWMNNDF5D9/+lRG/LGTstmwFFFVBw==",
+      "dependencies": {
+        "@liff/store": "2.22.3",
+        "@liff/use": "2.22.3"
+      },
+      "peerDependencies": {
+        "tslib": "^2.3.0"
+      }
+    },
+    "node_modules/@liff/message-bus": {
+      "version": "2.22.3",
+      "resolved": "https://registry.npmjs.org/@liff/message-bus/-/message-bus-2.22.3.tgz",
+      "integrity": "sha512-CR/E1Fkh+mWEx7+vk0u4QLwFPUlE9doDm/twKkkmdYkWbzDSNid+Hg2ifwABT0/hOgi5Z8BWqBz/B5b39sqGUw==",
+      "dependencies": {
+        "@liff/consts": "2.22.3",
+        "@liff/store": "2.22.3",
+        "@liff/util": "2.22.3"
+      },
+      "peerDependencies": {
+        "tslib": "^2.3.0"
+      }
+    },
+    "node_modules/@liff/native-bridge": {
+      "version": "2.22.3",
+      "resolved": "https://registry.npmjs.org/@liff/native-bridge/-/native-bridge-2.22.3.tgz",
+      "integrity": "sha512-q1GHTdAj0zt7a4fW224fXUa9aWMIlo/7zj6oZ+yGhPajiMsm/CTq0Zz7QBX8H2e699ScBSvjskqOzP+Dvp4APg==",
+      "dependencies": {
+        "@liff/consts": "2.22.3",
+        "@liff/logger": "2.22.3",
+        "@liff/store": "2.22.3",
+        "@liff/types": "2.22.3",
+        "@liff/util": "2.22.3"
+      },
+      "peerDependencies": {
+        "tslib": "^2.3.0"
+      }
+    },
+    "node_modules/@liff/open-window": {
+      "version": "2.22.3",
+      "resolved": "https://registry.npmjs.org/@liff/open-window/-/open-window-2.22.3.tgz",
+      "integrity": "sha512-xtPy+v8rRvnaSzXhTDfl/GdeMCIvz3xd0AI5RjlQ/+XQR8zPz8JG4qUPMk4W9mUFrUCwE19BBbnk2pm9YeZN2Q==",
+      "dependencies": {
+        "@liff/consts": "2.22.3",
+        "@liff/get-line-version": "2.22.3",
+        "@liff/get-os": "2.22.3",
+        "@liff/is-in-client": "2.22.3",
+        "@liff/native-bridge": "2.22.3",
+        "@liff/types": "2.22.3",
+        "@liff/use": "2.22.3",
+        "@liff/util": "2.22.3"
+      },
+      "peerDependencies": {
+        "tslib": "^2.3.0"
+      }
+    },
+    "node_modules/@liff/permanent-link": {
+      "version": "2.22.3",
+      "resolved": "https://registry.npmjs.org/@liff/permanent-link/-/permanent-link-2.22.3.tgz",
+      "integrity": "sha512-ZyHy6RnSVPqUtRiljEt8G86AXzYMCde7Xrpr/Ncrao6Sb6wQ7cPNLkIMYgvKUluqNtmwP5nsFBR8rkqAPFdsag==",
+      "dependencies": {
+        "@liff/consts": "2.22.3",
+        "@liff/server-api": "2.22.3",
+        "@liff/store": "2.22.3",
+        "@liff/use": "2.22.3",
+        "@liff/util": "2.22.3"
+      },
+      "peerDependencies": {
+        "tslib": "^2.3.0"
+      }
+    },
+    "node_modules/@liff/permission": {
+      "version": "2.22.3",
+      "resolved": "https://registry.npmjs.org/@liff/permission/-/permission-2.22.3.tgz",
+      "integrity": "sha512-j96QmxPxyI2A7ResOY5jnloUHLb+3hAuW0oc5ZYK1RHumsm1gATvESe7u+s5hYOhQ5mhXLY6WLVXpLcj8YB8sA==",
+      "dependencies": {
+        "@liff/consts": "2.22.3",
+        "@liff/is-api-available": "2.22.3",
+        "@liff/is-in-client": "2.22.3",
+        "@liff/server-api": "2.22.3",
+        "@liff/store": "2.22.3",
+        "@liff/sub-window": "2.22.3",
+        "@liff/use": "2.22.3",
+        "@liff/util": "2.22.3"
+      },
+      "peerDependencies": {
+        "tslib": "^2.3.0"
+      }
+    },
+    "node_modules/@liff/ready": {
+      "version": "2.22.3",
+      "resolved": "https://registry.npmjs.org/@liff/ready/-/ready-2.22.3.tgz",
+      "integrity": "sha512-4W9vyTDOksNAN9/h+NV1+2peUK48AE06FsZ2YTgFGQ6Z0ct0iq3wyZHaw4BzDb4zEzMt1yfUoodKb92c09T86g==",
+      "peerDependencies": {
+        "tslib": "^2.3.0"
+      }
+    },
+    "node_modules/@liff/scan-code": {
+      "version": "2.22.3",
+      "resolved": "https://registry.npmjs.org/@liff/scan-code/-/scan-code-2.22.3.tgz",
+      "integrity": "sha512-HnIOTIsBDxs6+hcqNAJgj5NCkrexcD4K+4GhLxVSumYp2h640nEVYcs8x+DqIwQZa/ShHwE06mBL95p2SA4/0Q==",
+      "dependencies": {
+        "@liff/types": "2.22.3"
+      },
+      "peerDependencies": {
+        "tslib": "^2.3.0"
+      }
+    },
+    "node_modules/@liff/scan-code-v2": {
+      "version": "2.22.3",
+      "resolved": "https://registry.npmjs.org/@liff/scan-code-v2/-/scan-code-v2-2.22.3.tgz",
+      "integrity": "sha512-kviiLAS5FHzXkZNLYr0akZuuLpA1ETSENsiV5eqALUyNH2l0XguEoqNs1TA77jIdUHj4g8EAZeQ0s12jsDZnaA==",
+      "dependencies": {
+        "@liff/consts": "2.22.3",
+        "@liff/is-api-available": "2.22.3",
+        "@liff/sub-window": "2.22.3",
+        "@liff/use": "2.22.3",
+        "@liff/util": "2.22.3"
+      },
+      "peerDependencies": {
+        "tslib": "^2.3.0"
+      }
+    },
+    "node_modules/@liff/send-messages": {
+      "version": "2.22.3",
+      "resolved": "https://registry.npmjs.org/@liff/send-messages/-/send-messages-2.22.3.tgz",
+      "integrity": "sha512-znBxydpZfPKEjnl8dgC8CIXETxgSc1zWd5VDRmItADhJT/C9hHVNp8+QMccTiv8VZHH6hQqAnlljhxb3y1KfHw==",
+      "dependencies": {
+        "@liff/consts": "2.22.3",
+        "@liff/get-line-version": "2.22.3",
+        "@liff/get-os": "2.22.3",
+        "@liff/permission": "2.22.3",
+        "@liff/server-api": "2.22.3",
+        "@liff/use": "2.22.3",
+        "@liff/util": "2.22.3",
+        "@line/bot-sdk": "^7.0.0"
+      },
+      "peerDependencies": {
+        "tslib": "^2.3.0"
+      }
+    },
+    "node_modules/@liff/server-api": {
+      "version": "2.22.3",
+      "resolved": "https://registry.npmjs.org/@liff/server-api/-/server-api-2.22.3.tgz",
+      "integrity": "sha512-Z7SXZtSiTpOp9V5f4Rej8BDiqlPRrzF+Xxx7rPC3n6WO7asHq9GdpnGYm6lwlf7oVgNbY6T1xJC33lXR8Pk9Sg==",
+      "dependencies": {
+        "@liff/consts": "2.22.3",
+        "@liff/store": "2.22.3",
+        "@liff/util": "2.22.3"
+      },
+      "peerDependencies": {
+        "tslib": "^2.3.0"
+      }
+    },
+    "node_modules/@liff/share-target-picker": {
+      "version": "2.22.3",
+      "resolved": "https://registry.npmjs.org/@liff/share-target-picker/-/share-target-picker-2.22.3.tgz",
+      "integrity": "sha512-gUDyX4wp2EtgW2wk260CVm3tLaIBZamqQD44zvD3d3079sNXXvfXwj3hRILlUp39jFBTGdemt4nDy+ZE8VpytA==",
+      "dependencies": {
+        "@liff/analytics": "2.22.3",
+        "@liff/consts": "2.22.3",
+        "@liff/get-line-version": "2.22.3",
+        "@liff/get-os": "2.22.3",
+        "@liff/is-api-available": "2.22.3",
+        "@liff/is-in-client": "2.22.3",
+        "@liff/is-logged-in": "2.22.3",
+        "@liff/is-sub-window": "2.22.3",
+        "@liff/logger": "2.22.3",
+        "@liff/send-messages": "2.22.3",
+        "@liff/server-api": "2.22.3",
+        "@liff/store": "2.22.3",
+        "@liff/types": "2.22.3",
+        "@liff/use": "2.22.3",
+        "@liff/util": "2.22.3",
+        "@liff/window-postmessage": "2.22.3"
+      },
+      "peerDependencies": {
+        "tslib": "^2.3.0"
+      }
+    },
+    "node_modules/@liff/store": {
+      "version": "2.22.3",
+      "resolved": "https://registry.npmjs.org/@liff/store/-/store-2.22.3.tgz",
+      "integrity": "sha512-8DHjpqAvDVrqkA8CMGCtOj/ZO+/dNHCjr1dYMOjHeEpjjf6iGTHym+UGnRYxj8zMSBDk+ujAhdw8Y8dNKm4/aQ==",
+      "dependencies": {
+        "@liff/consts": "2.22.3",
+        "@liff/is-in-client": "2.22.3",
+        "@liff/types": "2.22.3",
+        "@liff/use": "2.22.3",
+        "@liff/util": "2.22.3"
+      },
+      "peerDependencies": {
+        "tslib": "^2.3.0"
+      }
+    },
+    "node_modules/@liff/sub-window": {
+      "version": "2.22.3",
+      "resolved": "https://registry.npmjs.org/@liff/sub-window/-/sub-window-2.22.3.tgz",
+      "integrity": "sha512-uwi4HizVCcyZ1eIE+un6U0aIgsHvDvYnpdA8s12iOJ3FCbMBQH5fEfsAJLj+32+KXRWhbEF0U5MGA7E5iBWNGg==",
+      "dependencies": {
+        "@liff/close-window": "2.22.3",
+        "@liff/consts": "2.22.3",
+        "@liff/get-os": "2.22.3",
+        "@liff/is-api-available": "2.22.3",
+        "@liff/is-in-client": "2.22.3",
+        "@liff/is-sub-window": "2.22.3",
+        "@liff/logger": "2.22.3",
+        "@liff/message-bus": "2.22.3",
+        "@liff/server-api": "2.22.3",
+        "@liff/store": "2.22.3",
+        "@liff/use": "2.22.3",
+        "@liff/util": "2.22.3"
+      },
+      "peerDependencies": {
+        "tslib": "^2.3.0"
+      }
+    },
+    "node_modules/@liff/types": {
+      "version": "2.22.3",
+      "resolved": "https://registry.npmjs.org/@liff/types/-/types-2.22.3.tgz",
+      "integrity": "sha512-fWff3gSuwWpdAgFG1HrbPjwaADat5YJkErm3k+m9uH99uZ3FmufBR0MeM6kFUttixOEnZAKjHDj2BIrQ8PC+Dw=="
+    },
+    "node_modules/@liff/use": {
+      "version": "2.22.3",
+      "resolved": "https://registry.npmjs.org/@liff/use/-/use-2.22.3.tgz",
+      "integrity": "sha512-C5M2M4ihDP8sIQc28F2NWIr8wsbdHRZ03qv1PcBKoCYlQoJSkyTAbNrzy5anhGSVTTRiR2gAqkcwTRm5cI+rxA==",
+      "dependencies": {
+        "@liff/hooks": "2.22.3",
+        "@liff/logger": "2.22.3"
+      },
+      "peerDependencies": {
+        "tslib": "^2.3.0"
+      }
+    },
+    "node_modules/@liff/util": {
+      "version": "2.22.3",
+      "resolved": "https://registry.npmjs.org/@liff/util/-/util-2.22.3.tgz",
+      "integrity": "sha512-1QLw1pY4BH7LbQyBNpQmFW3eZYGG0pPS4msZYPOQd7J8gq/ENRYmkhxR5BkKYcGUAWD8T9FYeMEyKIGm0OVhbA==",
+      "dependencies": {
+        "@liff/consts": "2.22.3",
+        "@liff/logger": "2.22.3"
+      },
+      "peerDependencies": {
+        "tslib": "^2.3.0"
+      }
+    },
+    "node_modules/@liff/window-postmessage": {
+      "version": "2.22.3",
+      "resolved": "https://registry.npmjs.org/@liff/window-postmessage/-/window-postmessage-2.22.3.tgz",
+      "integrity": "sha512-WHbTysbLlPAEpEedYnU6ttTg0B54T9urJ64piRByrjfZ7w1DKdS7c34AcyvpNeG0JwZ3wyxaPLms6kjCFOXaVg==",
+      "dependencies": {
+        "@liff/consts": "2.22.3",
+        "@liff/logger": "2.22.3",
+        "@liff/util": "2.22.3"
+      },
+      "peerDependencies": {
+        "tslib": "^2.3.0"
+      }
+    },
     "node_modules/@line/bot-sdk": {
       "version": "7.5.2",
       "resolved": "https://registry.npmjs.org/@line/bot-sdk/-/bot-sdk-7.5.2.tgz",
@@ -10692,6 +12127,57 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/@line/liff": {
+      "version": "2.22.3",
+      "resolved": "https://registry.npmjs.org/@line/liff/-/liff-2.22.3.tgz",
+      "integrity": "sha512-wRNvH7jgqlKjPT+tn17sdoYAA28W9TOFShOzOiJhJhYYIg4/wmVKDMquTi7kKBFZZT4eum7TLX9lTcSn24tAzw==",
+      "dependencies": {
+        "@liff/analytics": "2.22.3",
+        "@liff/close-window": "2.22.3",
+        "@liff/consts": "2.22.3",
+        "@liff/core": "2.22.3",
+        "@liff/extensions": "2.22.3",
+        "@liff/get-friendship": "2.22.3",
+        "@liff/get-language": "2.22.3",
+        "@liff/get-line-version": "2.22.3",
+        "@liff/get-os": "2.22.3",
+        "@liff/get-profile": "2.22.3",
+        "@liff/get-version": "2.22.3",
+        "@liff/hooks": "2.22.3",
+        "@liff/i18n": "2.22.3",
+        "@liff/init": "2.22.3",
+        "@liff/is-api-available": "2.22.3",
+        "@liff/is-in-client": "2.22.3",
+        "@liff/is-logged-in": "2.22.3",
+        "@liff/is-sub-window": "2.22.3",
+        "@liff/liff-types": "2.22.3",
+        "@liff/login": "2.22.3",
+        "@liff/logout": "2.22.3",
+        "@liff/native-bridge": "2.22.3",
+        "@liff/open-window": "2.22.3",
+        "@liff/permanent-link": "2.22.3",
+        "@liff/permission": "2.22.3",
+        "@liff/ready": "2.22.3",
+        "@liff/scan-code-v2": "2.22.3",
+        "@liff/send-messages": "2.22.3",
+        "@liff/server-api": "2.22.3",
+        "@liff/share-target-picker": "2.22.3",
+        "@liff/store": "2.22.3",
+        "@liff/sub-window": "2.22.3",
+        "@liff/use": "2.22.3",
+        "@liff/util": "2.22.3",
+        "tslib": "^2.3.0",
+        "whatwg-fetch": "^3.0.0"
+      }
+    },
+    "node_modules/@line/liff-mock": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@line/liff-mock/-/liff-mock-1.0.3.tgz",
+      "integrity": "sha512-9js4YXheVV4rTXvvLIMVSqC6ikmD7mRrpbFqFZBemqCmSu3YSfljQs1fzKVy9LVUCREmsESLwWqa57jS3LY45g==",
+      "peerDependencies": {
+        "@line/liff": ">= 2.19.0"
       }
     },
     "node_modules/@manypkg/find-root": {
@@ -11042,6 +12528,60 @@
       "version": "4.16.1-1.4bc8b6e1b66cb932731fb1bdbbc550d1e010de81",
       "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-4.16.1-1.4bc8b6e1b66cb932731fb1bdbbc550d1e010de81.tgz",
       "integrity": "sha512-q617EUWfRIDTriWADZ4YiWRZXCa/WuhNgLTVd+HqWLffjMSPzyM5uOWoauX91wvQClSKZU4pzI4JJLQ9Kl62Qg=="
+    },
+    "node_modules/@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ=="
+    },
+    "node_modules/@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg=="
+    },
+    "node_modules/@protobufjs/codegen": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
+      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg=="
+    },
+    "node_modules/@protobufjs/eventemitter": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
+      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q=="
+    },
+    "node_modules/@protobufjs/fetch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
+      "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.1",
+        "@protobufjs/inquire": "^1.1.0"
+      }
+    },
+    "node_modules/@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ=="
+    },
+    "node_modules/@protobufjs/inquire": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
+      "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q=="
+    },
+    "node_modules/@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA=="
+    },
+    "node_modules/@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw=="
+    },
+    "node_modules/@protobufjs/utf8": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
+      "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="
     },
     "node_modules/@react-native-community/cli": {
       "version": "11.3.6",
@@ -17929,6 +19469,17 @@
         "reusify": "^1.0.4"
       }
     },
+    "node_modules/faye-websocket": {
+      "version": "0.11.4",
+      "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.11.4.tgz",
+      "integrity": "sha512-CzbClwlXAuiRQAlUyfqPgvPoNKTckTPGfwZV4ZdAhVcP2lh9KUxJg2b5GkE7XbjKQ3YJnQ9z6D9ntLAlB+tP8g==",
+      "dependencies": {
+        "websocket-driver": ">=0.5.1"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
     "node_modules/fb-watchman": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.2.tgz",
@@ -18174,6 +19725,39 @@
       },
       "engines": {
         "node": ">= 10.13.0"
+      }
+    },
+    "node_modules/firebase": {
+      "version": "10.3.1",
+      "resolved": "https://registry.npmjs.org/firebase/-/firebase-10.3.1.tgz",
+      "integrity": "sha512-lUk1X0SQocShyIwz5x9mj829Yn1y4Y9KWriGLZ0/Pbwqt4ZxElx8rI1p/YAi4MZTtT1qi0wazo7dAlmuF6J0Aw==",
+      "dependencies": {
+        "@firebase/analytics": "0.10.0",
+        "@firebase/analytics-compat": "0.2.6",
+        "@firebase/app": "0.9.18",
+        "@firebase/app-check": "0.8.0",
+        "@firebase/app-check-compat": "0.3.7",
+        "@firebase/app-compat": "0.2.18",
+        "@firebase/app-types": "0.9.0",
+        "@firebase/auth": "1.3.0",
+        "@firebase/auth-compat": "0.4.6",
+        "@firebase/database": "1.0.1",
+        "@firebase/database-compat": "1.0.1",
+        "@firebase/firestore": "4.1.3",
+        "@firebase/firestore-compat": "0.3.17",
+        "@firebase/functions": "0.10.0",
+        "@firebase/functions-compat": "0.3.5",
+        "@firebase/installations": "0.6.4",
+        "@firebase/installations-compat": "0.2.4",
+        "@firebase/messaging": "0.12.4",
+        "@firebase/messaging-compat": "0.2.4",
+        "@firebase/performance": "0.6.4",
+        "@firebase/performance-compat": "0.2.4",
+        "@firebase/remote-config": "0.4.4",
+        "@firebase/remote-config-compat": "0.2.4",
+        "@firebase/storage": "0.11.2",
+        "@firebase/storage-compat": "0.3.2",
+        "@firebase/util": "1.9.3"
       }
     },
     "node_modules/flagged-respawn": {
@@ -18807,6 +20391,11 @@
         "node": ">= 10.x"
       }
     },
+    "node_modules/hamt_plus": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/hamt_plus/-/hamt_plus-1.0.2.tgz",
+      "integrity": "sha512-t2JXKaehnMb9paaYA7J0BX8QQAY8lwfQ9Gjf4pg/mk4krt+cmwmU652HOoWonf+7+EQV97ARPMhhVgU1ra2GhA=="
+    },
     "node_modules/handlebars": {
       "version": "4.7.8",
       "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.8.tgz",
@@ -19017,6 +20606,11 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/http-parser-js": {
+      "version": "0.5.8",
+      "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.5.8.tgz",
+      "integrity": "sha512-SGeBX54F94Wgu5RH3X5jsDtf4eHyRogWX1XGT3b4HuW3tQPM4AaBzoUji/4AAJNXCEOWZ5O0DgZmJw1947gD5Q=="
     },
     "node_modules/http-proxy-agent": {
       "version": "4.0.1",
@@ -22536,8 +24130,7 @@
     "node_modules/lodash.camelcase": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
-      "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
-      "dev": true
+      "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA=="
     },
     "node_modules/lodash.debounce": {
       "version": "4.0.8",
@@ -22908,6 +24501,11 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/long": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.2.3.tgz",
+      "integrity": "sha512-lcHwpNoggQTObv5apGNCTdJrO69eHOZMi4BNC+rTLER8iHAqGrUVeLh/irVIM7zTw2bOXA8T6uNPeujwOLg/2Q=="
     },
     "node_modules/loose-envify": {
       "version": "1.4.0",
@@ -26552,6 +28150,34 @@
         "react-is": "^16.13.1"
       }
     },
+    "node_modules/protobufjs": {
+      "version": "7.2.5",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.2.5.tgz",
+      "integrity": "sha512-gGXRSXvxQ7UiPgfw8gevrfRWcTlSbOFg+p/N+JVJEK5VhueL2miT6qTymqAmjr1Q5WbOCyJbyrk6JfWKwlFn6A==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.4",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.0",
+        "@types/node": ">=13.7.0",
+        "long": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/protobufjs/node_modules/@types/node": {
+      "version": "20.5.9",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.5.9.tgz",
+      "integrity": "sha512-PcGNd//40kHAS3sTlzKB9C9XL4K0sTup8nbG5lC14kzEteTNuAFh9u5nA0o5TWnSG2r/JNPRXFVcHJIIeRlmqQ=="
+    },
     "node_modules/psl": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/psl/-/psl-1.9.0.tgz",
@@ -27046,6 +28672,25 @@
       },
       "engines": {
         "node": ">= 10.13.0"
+      }
+    },
+    "node_modules/recoil": {
+      "version": "0.7.7",
+      "resolved": "https://registry.npmjs.org/recoil/-/recoil-0.7.7.tgz",
+      "integrity": "sha512-8Og5KPQW9LwC577Vc7Ug2P0vQshkv1y3zG3tSSkWMqkWSwHmE+by06L8JtnGocjW6gcCvfwB3YtrJG6/tWivNQ==",
+      "dependencies": {
+        "hamt_plus": "1.0.2"
+      },
+      "peerDependencies": {
+        "react": ">=16.13.1"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        }
       }
     },
     "node_modules/redent": {
@@ -28685,6 +30330,11 @@
         "safe-buffer": "~5.1.0"
       }
     },
+    "node_modules/tiny-sha256": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/tiny-sha256/-/tiny-sha256-1.0.2.tgz",
+      "integrity": "sha512-IdsPtu8eJ0SwuCWUFm2euFH3jJvtpGQC0VpZNZlqxRvQ2zGvSjbXDO+4T8Rm5ETsmCQHHvKUGds69bJYrlb3Tg=="
+    },
     "node_modules/title-case": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/title-case/-/title-case-3.0.3.tgz",
@@ -29509,6 +31159,27 @@
         "node": ">=10.4"
       }
     },
+    "node_modules/websocket-driver": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.4.tgz",
+      "integrity": "sha512-b17KeDIQVjvb0ssuSDF2cYXSg2iztliJ4B9WdsuB6J952qCPKmnVq4DyW5motImXHDC1cBT/1UezrJVsKw5zjg==",
+      "dependencies": {
+        "http-parser-js": ">=0.5.1",
+        "safe-buffer": ">=5.1.0",
+        "websocket-extensions": ">=0.1.1"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/websocket-extensions": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.4.tgz",
+      "integrity": "sha512-OqedPIGOfsDlo31UNwYbCFMSaO9m9G/0faIHj5/dZFDMFqPTcx6UwqyOy3COEaEOg/9VsGIpdqn62W5KhoKSpg==",
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
     "node_modules/whatwg-encoding": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-1.0.5.tgz",
@@ -29521,8 +31192,7 @@
     "node_modules/whatwg-fetch": {
       "version": "3.6.17",
       "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.6.17.tgz",
-      "integrity": "sha512-c4ghIvG6th0eudYwKZY5keb81wtFz9/WeAHAoy8+r18kcWlitUIrmGFQ2rWEl4UCKUilD3zCLHOIPheHx5ypRQ==",
-      "peer": true
+      "integrity": "sha512-c4ghIvG6th0eudYwKZY5keb81wtFz9/WeAHAoy8+r18kcWlitUIrmGFQ2rWEl4UCKUilD3zCLHOIPheHx5ypRQ=="
     },
     "node_modules/whatwg-mimetype": {
       "version": "2.3.0",

--- a/package.json
+++ b/package.json
@@ -38,12 +38,15 @@
   },
   "dependencies": {
     "@line/bot-sdk": "^7.5.2",
+    "@line/liff": "^2.22.3",
+    "@line/liff-mock": "^1.0.3",
     "@prisma/client": "^4.14.1",
     "@tailwindcss/forms": "^0.5.4",
     "aws-amplify": "^5.2.1",
     "aws-sdk": "^2.1359.0",
     "classnames": "^2.3.2",
     "dayjs": "^1.11.7",
+    "firebase": "^10.3.1",
     "lodash": "^4.17.21",
     "next": "^13.0.6",
     "next-connect": "^0.13.0",
@@ -52,6 +55,7 @@
     "react-hot-toast": "^2.4.0",
     "react-icons": "^4.9.0",
     "react-swipeable": "^7.0.0",
+    "recoil": "^0.7.7",
     "sharp": "^0.32.4",
     "swr": "^2.1.5",
     "uuid": "^9.0.0"

--- a/src/client/components/providers/Liff/index.tsx
+++ b/src/client/components/providers/Liff/index.tsx
@@ -1,0 +1,33 @@
+import Script from 'next/script';
+import { FC, PropsWithChildren } from 'react';
+import { useLiffUserState } from '~/client/feature/liff/useLiff';
+
+const LiffScript: FC<{
+  liffId: string;
+}> = ({ liffId }) => {
+  const { initialize } = useLiffUserState({
+    liffId,
+  });
+  return (
+    <Script
+      src="https://static.line-scdn.net/liff/edge/2/sdk.js"
+      onLoad={initialize}
+    />
+  );
+};
+
+/**
+ * @description LIFF SDK を読み込むためのプロバイダー
+ */
+export const LiffProvider: FC<
+  PropsWithChildren<{
+    liifId: string;
+  }>
+> = ({ children, liifId }) => {
+  return (
+    <>
+      <LiffScript liffId={liifId} />
+      {children}
+    </>
+  );
+};

--- a/src/client/components/providers/Root/index.tsx
+++ b/src/client/components/providers/Root/index.tsx
@@ -1,6 +1,7 @@
 import { AppProps } from 'next/app';
 import { FC } from 'react';
 import { Toaster } from 'react-hot-toast';
+import { RecoilRoot } from 'recoil';
 import { SWRConfig } from 'swr';
 import { NextPageWithLayout } from '~/types/next';
 
@@ -22,7 +23,7 @@ export const RootProvider: FC<AppPropsWithLayout> = ({
   const getLayout = Component.getLayout || ((page) => page);
 
   const component = getLayout(
-    <>
+    <RecoilRoot>
       <Toaster position="top-center" />
       <SWRConfig
         value={{
@@ -32,7 +33,7 @@ export const RootProvider: FC<AppPropsWithLayout> = ({
       >
         <Component {...pageProps} />
       </SWRConfig>
-    </>
+    </RecoilRoot>
   );
 
   return component;

--- a/src/client/feature/liff/index.ts
+++ b/src/client/feature/liff/index.ts
@@ -1,0 +1,58 @@
+import liff from '@line/liff';
+import { Liff } from '@line/liff/exports';
+import { LiffMockPlugin } from '@line/liff-mock';
+
+liff.use(new LiffMockPlugin());
+
+export class LiffUser {
+  private readonly _liff: Liff;
+  private readonly _config: Parameters<Liff['init']>[0];
+  isLoggedIn: boolean = false;
+  userId: string = '';
+  idToken: string = '';
+  displayName: string = '';
+  pictureUrl?: string = undefined;
+  statusMessage?: string = undefined;
+
+  constructor(liff: Liff, config: Parameters<Liff['init']>[0]) {
+    this._liff = liff;
+    this._config = config;
+  }
+
+  static async create(...args: ConstructorParameters<typeof LiffUser>) {
+    const instance = new LiffUser(...args);
+    await instance._init();
+    return instance;
+  }
+
+  private async _init() {
+    await this._liff.init(
+      this._config,
+      async () => {
+        this.isLoggedIn = liff.isLoggedIn();
+        this.idToken = liff.getIDToken();
+
+        const profile = await liff.getProfile();
+        this.userId = profile.userId;
+        this.displayName = profile.displayName;
+        this.pictureUrl = profile.pictureUrl;
+        this.statusMessage = profile.statusMessage;
+      },
+      (error) => {
+        throw error;
+      }
+    );
+  }
+
+  login() {
+    this._liff.login();
+  }
+
+  logout() {
+    this._liff.logout();
+  }
+
+  closeWindow() {
+    this._liff.closeWindow();
+  }
+}

--- a/src/client/feature/liff/useLiff.ts
+++ b/src/client/feature/liff/useLiff.ts
@@ -1,0 +1,23 @@
+import liff from '@line/liff';
+import { useCallback } from 'react';
+import { atom, useRecoilState } from 'recoil';
+import { LiffUser } from '~/client/feature/liff';
+
+const liffUserState = atom<LiffUser | null>({
+  key: 'liffUserState',
+  default: null,
+});
+
+export const useLiffUserState = (config: Parameters<typeof liff.init>[0]) => {
+  const [liffUser, setLiffUser] = useRecoilState(liffUserState);
+
+  const initialize = useCallback(async () => {
+    const liffUser = await LiffUser.create(liff, config);
+    setLiffUser(liffUser);
+  }, [config, setLiffUser]);
+
+  return {
+    liffUser,
+    initialize,
+  };
+};


### PR DESCRIPTION
## 背景
新たにRecoilというステート管理ライブラリを導入し、またLINEのLIFF SDKを利用することになりました。
これに伴い、必要なパッケージを追加し、Recoilをアプリケーション全体で利用できるようにするための変更を行いました。

## 概要
このPull Requestでは、アプリケーションの`package.json`に
新たに`@line/liff`, @line/liff-mock, firebase, recoilを追加しました。
また、Recoilをアプリケーション全体で利用可能にするために、`RootProvider`コンポーネントを更新しました。

## 変更点
- package.jsonに`@line/liff`, @line/liff-mock, firebase, recoilを追加
- RootProviderコンポーネントで`RecoilRoot`を使用してアプリケーション全体でRecoilを利用可能に

## 参考
- https://github.com/hyodoblog/liff-nextjs-template/tree/main
- https://github.com/coji/mpa-liff-vite/blob/main/src/features/liff/hooks/useLiff.ts